### PR TITLE
Rename long lived token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Creating release
       uses: actions/create-release@v1.0.0
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_LL_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.LL_GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
@@ -63,7 +63,7 @@ jobs:
       id: get-release-info
       uses: dldt/get-release-info@v1.0.0
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_LL_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.LL_GITHUB_TOKEN }}
       with:
         tag-name: ${{ github.ref }}
     - name: Downloading artifacts
@@ -81,13 +81,13 @@ jobs:
       id: get-release-info2
       uses: dldt/get-release-info@v1.0.0
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_LL_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.LL_GITHUB_TOKEN }}
       with:
         tag-name: ${{ github.ref }}
     - name: Uploading release assets
       uses: actions/upload-release-asset@v1.0.1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_LL_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.LL_GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.get-release-info2.outputs.upload_url }}
         asset_path: ./${{ github.event.repository.name }}-${{ matrix.os }}-${{ steps.get-release-info2.outputs.tag-name }}.zip


### PR DESCRIPTION
Had to renew it and it seems that github does allow token starting with
GITHUB anymore.